### PR TITLE
Supports setup.py projects if no requirements.txt found

### DIFF
--- a/bin/pyinstaller.sh
+++ b/bin/pyinstaller.sh
@@ -12,6 +12,8 @@ PATH="/pyinstaller:$PATH"
 
 if [ -f requirements.txt ]; then
     pip install -r requirements.txt
+elif [ -f setup.py ]; then
+    pip install .
 fi
 
 # Exclude pycrypto and PyInstaller from built packages


### PR DESCRIPTION
Simple update, simply checks for a setup.py if requirements.txt isn't found to install app requirements prior to running the pyinstaller command.