### PR TITLE
make alpine version and repo name optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Official Python base image is needed or some applications will segfault.
-FROM python:2.7-alpine
+FROM python:$ALPINE_VERSION-alpine
 
 # PyInstaller needs zlib-dev, gcc, libc-dev, and musl-dev
 RUN apk --update --no-cache add \
@@ -15,7 +15,7 @@ RUN apk --update --no-cache add \
 RUN pip install \
     pycrypto
 
-ARG PYINSTALLER_TAG=v3.2
+ARG PYINSTALLER_TAG=$PYINSTALLER_TAG
 
 # Build bootloader for alpine
 RUN git clone --depth 1 --single-branch --branch $PYINSTALLER_TAG https://github.com/pyinstaller/pyinstaller.git /tmp/pyinstaller \

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-export PYINSTALLER_TAG=${1:-v3.3}
-export ALPINE_VERSION=${2:-v3.4}
+export PYINSTALLER_TAG=${1:-v3.4}
+export ALPINE_VERSION=${2:-3.6}
+export REPO=${3:-six8/pyinstaller-alpine}
 
-REPO="six8/pyinstaller-alpine:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}"
+REPO="${REPO}:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}"
 
-docker build \
+cat Dockerfile | envsubst | docker build -f - \
     --build-arg PYINSTALLER_TAG=${PYINSTALLER_TAG} \
+    --build-arg ALPINE_VERSION=${ALPINE_VERSION} \
     -t $REPO .
 
 docker push $REPO


### PR DESCRIPTION
Thanks for this great job. It saved a lot time. I needed the python:alpine 3.6 with pyinstaller v3.4. I modified `Dockerfile` manually and it worked for me!. :)

So I added a few simple lines and now you can specify alpine version and repo name while building.

```bash
./build.sh v3.4 3.6 repo_name
```
Thanks again.
