### PR TITLE
Docker images for ARM32v7 and ARM64v8; Add -Wno-stringop-overflow;

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,48 @@
+version: 2.1
+executors:
+  python:
+    docker:
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: circleci/python:3.6.1
+  publisher:
+    docker:
+      - image: docker:18.06.0-ce
+jobs:
+  build:
+    executor: publisher
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 18.06.0-ce
+      - run: docker run --privileged linuxkit/binfmt:v0.6
+      - attach_workspace:
+          at: .
+      - run: make build REPOSITORY="${DOCKER_REGISTRY}"
+  buiil_n_publish:
+    executor: publisher
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 18.06.0-ce
+      - run: docker run --privileged linuxkit/binfmt:v0.6
+      - attach_workspace:
+          at: .
+      - run: apk add --no-cache make bash git
+      - run: make build REPOSITORY="${DOCKER_REGISTRY}"
+      - run: docker login -u "${DOCKER_REGISTRY_USER}" -p "${DOCKER_REGISTRY_PASSWORD}"
+      - run: make push REPOSITORY="${DOCKER_REGISTRY}"
+      - run: make manifest REPOSITORY="${DOCKER_REGISTRY}"
+workflows:
+  version: 2
+  kubeyaml:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: develop
+      - buiil_n_publish:
+          filters:
+            branches:
+              only: develop

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
-# Official Python base image is needed or some applications will segfault.
-FROM python:$ALPINE_VERSION-alpine
+ARG ARCH=""
+ARG ALPINE_VERSION="3.6"
 
+FROM ${ARCH}python:${ALPINE_VERSION}-alpine
+
+ARG PYINSTALLER_TAG
+ENV PYINSTALLER_TAG ${PYINSTALLER_TAG:-"v3.4"}
+
+# Official Python base image is needed or some applications will segfault.
 # PyInstaller needs zlib-dev, gcc, libc-dev, and musl-dev
 RUN apk --update --no-cache add \
     zlib-dev \
@@ -15,12 +21,10 @@ RUN apk --update --no-cache add \
 RUN pip install \
     pycrypto
 
-ARG PYINSTALLER_TAG=$PYINSTALLER_TAG
-
 # Build bootloader for alpine
-RUN git clone --depth 1 --single-branch --branch $PYINSTALLER_TAG https://github.com/pyinstaller/pyinstaller.git /tmp/pyinstaller \
+RUN git clone --depth 1 --single-branch --branch ${PYINSTALLER_TAG} https://github.com/pyinstaller/pyinstaller.git /tmp/pyinstaller \
     && cd /tmp/pyinstaller/bootloader \
-    && python ./waf configure --no-lsb all \
+    && CFLAGS="-Wno-stringop-overflow" python ./waf configure --no-lsb all \
     && pip install .. \
     && rm -Rf /tmp/pyinstaller
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+.DEFAULT: all
+.PHONY: all
+
+REPOSITORY ?= six8
+NAME := pyinstaller-alpine
+PYINSTALLER_TAG := v3.4
+ALPINE_VERSION := 3.6
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+SUFFIX ?= -$(subst /,-,$(BRANCH))
+
+all: build
+
+build: Dockerfile
+	@./build.sh "$(REPOSITORY)/$(NAME)-linux-amd64" "" "${PYINSTALLER_TAG}" "${ALPINE_VERSION}"
+	@./build.sh "$(REPOSITORY)/$(NAME)-linux-armv7" "arm32v7/" "${PYINSTALLER_TAG}" "${ALPINE_VERSION}"
+	@./build.sh "$(REPOSITORY)/$(NAME)-linux-arm64" "arm64v8/" "${PYINSTALLER_TAG}" "${ALPINE_VERSION}"
+
+push:
+	# Push docker images
+	docker push "$(REPOSITORY)/$(NAME)-linux-amd64:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}"
+	docker push "$(REPOSITORY)/$(NAME)-linux-armv7:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}"
+	docker push "$(REPOSITORY)/$(NAME)-linux-arm64:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}"
+
+manifest:
+	# Manifest for alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(REPOSITORY)/$(NAME):alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}" \
+		"$(REPOSITORY)/$(NAME)-linux-amd64:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}" \
+		"$(REPOSITORY)/$(NAME)-linux-armv7:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}" \
+		"$(REPOSITORY)/$(NAME)-linux-arm64:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}"
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(REPOSITORY)/$(NAME):alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}"
+	# Manifest for $(REPOSITORY)/$(NAME):latest
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(REPOSITORY)/$(NAME):latest" \
+		"$(REPOSITORY)/$(NAME)-linux-amd64:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}" \
+		"$(REPOSITORY)/$(NAME)-linux-armv7:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}" \
+		"$(REPOSITORY)/$(NAME)-linux-arm64:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}"
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(REPOSITORY)/$(NAME):latest"
+

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
-export PYINSTALLER_TAG=${1:-v3.4}
-export ALPINE_VERSION=${2:-3.6}
-export REPO=${3:-six8/pyinstaller-alpine}
+REPOSITORY=${1:-six8/pyinstaller-alpine-linux-amd64}
+ARCH=${2:-''}
+PYINSTALLER_TAG=${3:-v3.4}
+ALPINE_VERSION=${4:-3.6}
 
-REPO="${REPO}:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}"
+docker build -t ${REPOSITORY}:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG} \
+	--build-arg ARCH=${ARCH} \
+	--build-arg PYINSTALLER_TAG=${PYINSTALLER_TAG} \
+	--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
+	.
 
-cat Dockerfile | envsubst | docker build -f - \
-    --build-arg PYINSTALLER_TAG=${PYINSTALLER_TAG} \
-    --build-arg ALPINE_VERSION=${ALPINE_VERSION} \
-    -t $REPO .
-
-docker push $REPO


### PR DESCRIPTION
Addresses: #5 and #4 

* Refactored build system (added Makefile);
* Refactored Dockerfile;
* Fixed build with GCC 8.3;

In order to adopt this changes you will have to:
1. Register circleci.com account and configure project (it should pick up the .circleci/config.yml i have created for you)
2. Add following env variables:
- DOCKER_REGISTRY
- DOCKER_REGISTRY_PASSWORD
- DOCKER_REGISTRY_USER
3. Create additional repositories (for staging images, final manifests will be landed into pyinstaller-alpine):
- pyinstaller-alpine-linux-armv7
- pyinstaller-alpine-linux-arm64
- pyinstaller-alpine-linux-amd64

Note 1: Current CI\CD configuration will build and push images for each change in `develop` branch. Any other branch will trigger build-only (this might be useful to test pull requests and ongoing development)

Note 2: quay.io is not supporting docker manifest.v2 yet (in case if you was planning to use quay.io instead of docker.hub in future)

Repo structure example: https://hub.docker.com/u/brezerk 
Build example: https://circleci.com/gh/brezerk/pyinstaller-alpine/52

Let me know if you need any help.

Resulting image:

```
[ himera ] brezerk@pts/0:243  ~/develop/pyinstaller-alpine $
 05/12/19 20:27:48 EEST > docker run --rm weshigbee/manifest-tool inspect brezerk/pyinstaller-alpine:latest                                         
Name:   brezerk/pyinstaller-alpine:latest (Type: application/vnd.docker.distribution.manifest.list.v2+json)
Digest: sha256:d016cb769e62a7ec4586f4bfb0ac3a6ab005c9d85efd6b5a8b2c3f3865800bac
 * Contains 3 manifest references:
1    Mfst Type: application/vnd.docker.distribution.manifest.v2+json
1       Digest: sha256:27864aae412414389e5971074432c7300f235da0471119dc4291aefb2c1350e3
1  Mfst Length: 2622
1     Platform:
1           -      OS: linux
1           -    Arch: amd64
1           - Variant: 
1           - Feature: 
1     # Layers: 11
         layer 1: digest = sha256:e7c96db7181be991f19a9fb6975cdbbd73c65f4a2681348e63a141a2192a5f10
         layer 2: digest = sha256:799a5534f213d4fa33305a25e1987f38be3dc015267400efab141fb1ee9071e0
         layer 3: digest = sha256:913b50bbe755394b4d4bb87d1e2fee5bb63dc41a1059a59e4f98c13446ff3e58
         layer 4: digest = sha256:11154abc60811ff7350dfd0101213f864a1fbd34c85b60a5b7a951417d380cb2
         layer 5: digest = sha256:c805e63f69fecabe254d2c108a81fcd5bb8557c8e6bbcb8f3c6a99157b36a7dd
         layer 6: digest = sha256:4ee8c38955ff2fbf485aedb8aa367654029c106e3ed721753b11773844bee507
         layer 7: digest = sha256:ec2e27442b4b6df074e314eeccd4460a8e24a969e5414440d71f511a84a81693
         layer 8: digest = sha256:a8b084532cf87ce3491f6dd59ef5b59e5ab2a55c6c4c846275a13e9b5adc955c
         layer 9: digest = sha256:d75c7c1db231f318f94dc93e9768ba1c91875cf8617d43bf7a9dcd15cc7313f9
         layer 10: digest = sha256:0d607080217e9270c426932b8b87361a6329096c59216d85b9c340e16806220c
         layer 11: digest = sha256:a0bb9129c29fe693249b37e6337815d188ad1996625ea0d1efde5841e3a850b2

2    Mfst Type: application/vnd.docker.distribution.manifest.v2+json
2       Digest: sha256:1ff7425a6a820016a0d96710b2d0a729019077b8abc462a72087a8dc325a1346
2  Mfst Length: 2622
2     Platform:
2           -      OS: linux
2           -    Arch: arm64
2           - Variant: 
2           - Feature: 
2     # Layers: 11
         layer 1: digest = sha256:0362ad1dd800a9d92f8982fa28f173f9120266153830f990f7486f44b068968a
         layer 2: digest = sha256:a36acd288eb3d786a9aac76c818d76aa74f8ad9ff45d1fbd8f4f28f4b46a127f
         layer 3: digest = sha256:e812fe2329f82e1caa97a78d91490e5d8dc1e46e97fb2dcedc6fbd5a0b1ebf26
         layer 4: digest = sha256:bb529435b07540af4ab6479383fa0cdd8d26985a8e18edb2458d843511f4207d
         layer 5: digest = sha256:bf9cbf05fd771ae07fc8e03431ca10ba6a83d9ace4cbe61610896be14fc7d7c9
         layer 6: digest = sha256:36e47e4145b50f5f94a3406ac3df3ab5b54716a87f7508a7442b194ce46cf8df
         layer 7: digest = sha256:c92e5b6cb62fb6945a4bb5b28795c875ad622262a82352f2e14df83b660997ee
         layer 8: digest = sha256:9952c515cbf55fc12b8dae330e03038e66b0da6f18c15ecb2c5e731e29845e90
         layer 9: digest = sha256:eac6584374189169b161c85d235079fdfeeaa13ebba410d57f5f8ef871e30580
         layer 10: digest = sha256:85cd7e2a17c55586be6e6aec900921b2018dff0e61783a41ebfd7ffac8126058
         layer 11: digest = sha256:814635b3f359e06220e34d8d1508ce915e8e2154205ac0550083e874554c6d28

3    Mfst Type: application/vnd.docker.distribution.manifest.v2+json
3       Digest: sha256:93dd38bc5963dda8c5e6d2b4ac2dea5938ec45bdf990c13583918658d29eed36
3  Mfst Length: 2622
3     Platform:
3           -      OS: linux
3           -    Arch: arm
3           - Variant: 
3           - Feature: 
3     # Layers: 11
         layer 1: digest = sha256:856f4240f8dba160c5323506c1e9a4dbaaca840bf1b0c244af3b8d1b42b0f43b
         layer 2: digest = sha256:dd44f171dea9d0d9d60e99f876258731e53fb44d78125b4b1fa9e292d2ff8d26
         layer 3: digest = sha256:819e3cf90f7cf439b36aa09620b37507045da0fc5915194a136a683d15f2fc50
         layer 4: digest = sha256:776653304d098d1fd3f8333024802beed2cef36aab7bcbce08ed09ec92879864
         layer 5: digest = sha256:5e10600a2846f292a12155015f4c3a9d70be046c446282b6ee5dd4f5140b6298
         layer 6: digest = sha256:bda1885bbb8f4eaf293d71f319315189df7a0739fb8d946172be28d12073f0af
         layer 7: digest = sha256:301239e5d0557f582c141c26bae5545a60ac139c1c67a51bcc2f49a5eb2bb870
         layer 8: digest = sha256:ae3b269719245ef276700c4f065a54946d0b282946e726cd5feeaea4b304a24f
         layer 9: digest = sha256:5d39b69007cc5bba5cbd8ccf43bae2dffeedc32739e2fb9dbf26ecc1bf7d71fe
         layer 10: digest = sha256:d4df86b9c3df01111b1b2daf0ed895f92567731c387a9e9c04a298bc898ab4a1
         layer 11: digest = sha256:eefc1261a7094575f028ec13456d1ab3a0ce86e02ce2c79e5f077ce088df8da7

```