### PR TITLE
Support building packages that need g++ or libffi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN apk --update --no-cache add \
     zlib-dev \
     musl-dev \
     libc-dev \
+    libffi-dev \
     gcc \
+    g++ \
     git \
     pwgen \
     && pip install --upgrade pip


### PR DESCRIPTION
For example: pycares and cchardet