### PR TITLE
Update python library: Colorama 

### DIFF
--- a/python2.7.Dockerfile
+++ b/python2.7.Dockerfile
@@ -25,7 +25,8 @@ RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && pip --vers
 
 # Install pycrypto so --key can be used with PyInstaller
 RUN pip install \
-    pycrypto
+    pycrypto \
+    colorama
 
 # Build bootloader for alpine
 RUN git clone --depth 1 --single-branch --branch ${PYINSTALLER_TAG} https://github.com/pyinstaller/pyinstaller.git /tmp/pyinstaller \

--- a/python3.7.Dockerfile
+++ b/python3.7.Dockerfile
@@ -21,7 +21,8 @@ RUN apk --update --no-cache add \
 
 # Install pycrypto so --key can be used with PyInstaller
 RUN pip install \
-    pycrypto
+    pycrypto \
+    colorama
 
 # Build bootloader for alpine
 RUN git clone --depth 1 --single-branch --branch ${PYINSTALLER_TAG} https://github.com/pyinstaller/pyinstaller.git /tmp/pyinstaller \


### PR DESCRIPTION
Colorama is built-in python library on Ubuntu, but it is not included in Alpine, so I update it.

Hope you can take a quick view on it.

Detail of the package is provided below:

- https://pypi.org/project/colorama/
- Requires: Python >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*